### PR TITLE
fix: Preserve empty headers

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -218,15 +218,19 @@ func TestMilterClient_UsualFlow(t *testing.T) {
 	hdr := textproto.Header{}
 	hdr.Add("From", "from@example.org")
 	hdr.Add("To", "to@example.org")
+	hdr.Add("x-empty-header", "")
 	act, err = session.Header(hdr)
 	assertAction(act, err, ActContinue)
-	if len(mm.Hdr) != 2 {
+	if len(mm.Hdr) != 3 {
 		t.Fatal("Unexpected header length:", len(mm.Hdr))
 	}
 	if val := mm.Hdr.Get("From"); val != "from@example.org" {
 		t.Fatal("Wrong From header:", val)
 	}
 	if val := mm.Hdr.Get("To"); val != "to@example.org" {
+		t.Fatal("Wrong To header:", val)
+	}
+	if val := mm.Hdr.Get("x-empty-header"); val != "" {
 		t.Fatal("Wrong To header:", val)
 	}
 

--- a/session.go
+++ b/session.go
@@ -177,6 +177,10 @@ func (m *milterSession) Process(msg *Message) (Response, error) {
 		}
 		// add new header to headers map
 		headerData := decodeCStrings(msg.Data)
+		// headers with an empty body appear as `text\x00\x00`, decodeCStrings will drop the empty body
+		if len(headerData) == 1 {
+			headerData = append(headerData, "")
+		}
 		if len(headerData) == 2 {
 			m.headers.Add(headerData[0], headerData[1])
 			// call and return milter handler


### PR DESCRIPTION
Ensure if a header is received without a body, it is preserved with an empty string as it's body.